### PR TITLE
feat: Add new character 'Moff Gideon'

### DIFF
--- a/src/Reference.GitHubActions/StarWarsNames.cs
+++ b/src/Reference.GitHubActions/StarWarsNames.cs
@@ -77,6 +77,7 @@ namespace Reference.GitHubActions
             "Mara Jade",
             "Mas Amedda",
             "Mission Vao",
+            "Moff Gideon",
             "Natasi Daala",
             "Nom Anor",
             "Obi-Wan Kenobi",


### PR DESCRIPTION
Imperial governor active in the years after the fall of the Empire who oversaw the massacre of the Mandalorian people. He seeks to capture the Child for unknown reasons, and is the Mandalorian's main enemy.